### PR TITLE
Remove the codecov patch check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        branches:
-        threshold: 1%
-    patch:
-      default:
-        threshold: 1% 


### PR DESCRIPTION
We can use the default codecov settings which don't do the patch check but do check the overall project.
