### PR TITLE
Update pyyaml to 3.13 because of CVE-2017-18342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+ - Update pyyaml to 3.13 because of CVE-2017-18342
 
 ### 0.2.1 2017-10-12
   - Allow multiple keys to be used to facilitate key rotation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 cryptography==1.9
 jwcrypto==0.4.0
-PyYAML==3.12
+PyYAML==3.13


### PR DESCRIPTION
## What? and Why?
Update pyyaml to 3.13 because of CVE-2017-18342