### PR TITLE
Create public key IDs more consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Unreleased
+- Create public key IDs more consistently
 
 ### 0.2.3 2018-07-31
 - Update cryptography and jwcrypto due to CVE-2018-10903

--- a/sdc/crypto/scripts/generate_keys.py
+++ b/sdc/crypto/scripts/generate_keys.py
@@ -5,7 +5,12 @@ import os
 import argparse
 
 from cryptography.hazmat.backends.openssl.backend import backend
-from cryptography.hazmat.primitives.serialization import load_pem_private_key, Encoding, PublicFormat
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
+    Encoding,
+    PublicFormat,
+)
 import yaml
 from yaml.representer import SafeRepresenter
 
@@ -118,7 +123,10 @@ def get_public_key(platform, service, purpose, key_use, version, public_key, key
     '''
     public_key_data = get_file_contents(keys_folder, public_key)
 
-    kid = _generate_kid_from_key(public_key_data)
+    pub_key = load_pem_public_key(public_key_data.encode(), backend=backend)
+    pub_bytes = pub_key.public_bytes(Encoding.PEM, PublicFormat.SubjectPublicKeyInfo)
+
+    kid = _generate_kid_from_key(pub_bytes.decode())
 
     key = _create_key(platform=platform, service=service, key_use=key_use,
                       key_type="public", purpose=purpose, version=version,


### PR DESCRIPTION
## What? and Why?
generate_keys.py takes a set of public and private key files and serializes them to a YAML file along with metadata to aid key pair discovery.

All keys get a key ID. Public key IDs are generated from a hash of their contents. Private key IDs are generated from a hash of their public key. Therefore the IDs of a public/private key pair should always match.

For public keys the previous code would hash the full contents of the provided PEM file. If this didn't exactly match the contents of the public key derived from corresponding private key then the IDs wouldn't match and the key pair would not function. This could be as simple as the PEM file not having a new line at the end.

This change runs the PEM file contents through the cryptography library so that the public key data being hashed should be consistent.

## Checklist
  - [x] CHANGELOG.md updated? (if required)
