### PR TITLE
Extend to allow selecting by service

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E402
+ignore = E402,W503
 max-line-length=160

--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ sdist:
 
 test:
 	flake8 .
-	pytest -v --cov-report term-missing --cov sdc.crypto --cov-fail-under=84
+	pytest -v --cov-report term-missing --cov sdc.crypto --cov-fail-under=87

--- a/README.md
+++ b/README.md
@@ -70,11 +70,11 @@ validate_required_secrets(secrets_from_file, EXPECTED_SECRETS, KEY_PURPOSE_SUBMI
 
 key_store = KeyStore(secrets_from_file)
 
-# Encrypt JSON (Purpose has a single key)
+# Encrypt JSON (Purpose has a single encryption key in the key store)
 from sdc.crypto.encrypter import encrypt
 encrypted_json = encrypt(json, key_store, key_purpose)
 
-# Encrypt JSON with encryption service (Purpose has a multiple keys)
+# Encrypt JSON with encryption service (Purpose has multiple encryption keys in the key store each tagged with a service)
 from sdc.crypto.encrypter import encrypt
 encrypted_json = encrypt(json, key_store, key_purpose, encryption_for_service="some-service")
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,13 @@ validate_required_secrets(secrets_from_file, EXPECTED_SECRETS, KEY_PURPOSE_SUBMI
 
 key_store = KeyStore(secrets_from_file)
 
-# Encrypt json
+# Encrypt JSON (Purpose has a single key)
 from sdc.crypto.encrypter import encrypt
 encrypted_json = encrypt(json, key_store, key_purpose)
+
+# Encrypt JSON with encryption service (Purpose has a multiple keys)
+from sdc.crypto.encrypter import encrypt
+encrypted_json = encrypt(json, key_store, key_purpose, encryption_service="some-service")
 
 # Decrypt UTF8 jwe token
 from sdc.crypto.decrypter import decrypt

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ encrypted_json = encrypt(json, key_store, key_purpose)
 
 # Encrypt JSON with encryption service (Purpose has a multiple keys)
 from sdc.crypto.encrypter import encrypt
-encrypted_json = encrypt(json, key_store, key_purpose, encryption_service="some-service")
+encrypted_json = encrypt(json, key_store, key_purpose, encryption_for_service="some-service")
 
 # Decrypt UTF8 jwe token
 from sdc.crypto.decrypter import decrypt

--- a/sdc/crypto/encrypter.py
+++ b/sdc/crypto/encrypter.py
@@ -2,13 +2,13 @@ from sdc.crypto.jwe_helper import JWEHelper
 from sdc.crypto.jwt_helper import JWTHelper
 
 
-def encrypt(json, key_store, key_purpose, encryption_service=None):
+def encrypt(json, key_store, key_purpose, encryption_for_service=None):
     """This encrypts the supplied json and returns a jwe token.
 
     :param str json: The json to be encrypted.
     :param key_store: The key store.
     :param str key_purpose: Context for the key.
-    :param Optional[str] encryption_service: The name of the encryption service
+    :param Optional[str] encryption_for_service: The name of the downstream service the JWT is being encrypted for
     :return: A jwe token.
 
     """
@@ -16,6 +16,6 @@ def encrypt(json, key_store, key_purpose, encryption_service=None):
 
     payload = JWTHelper.encode(json, jwt_key.kid, key_store, key_purpose)
 
-    jwe_key = key_store.get_key(purpose=key_purpose, key_type="public", service=encryption_service)
+    jwe_key = key_store.get_key(purpose=key_purpose, key_type="public", service=encryption_for_service)
 
     return JWEHelper.encrypt(payload, jwe_key.kid, key_store, key_purpose)

--- a/sdc/crypto/encrypter.py
+++ b/sdc/crypto/encrypter.py
@@ -2,19 +2,20 @@ from sdc.crypto.jwe_helper import JWEHelper
 from sdc.crypto.jwt_helper import JWTHelper
 
 
-def encrypt(json, key_store, key_purpose):
+def encrypt(json, key_store, key_purpose, encryption_service=None):
     """This encrypts the supplied json and returns a jwe token.
 
     :param str json: The json to be encrypted.
     :param key_store: The key store.
     :param str key_purpose: Context for the key.
+    :param Optional[str] encryption_service: The name of the encryption service
     :return: A jwe token.
 
     """
-    jwt_key = key_store.get_key_for_purpose_and_type(key_purpose, "private")
+    jwt_key = key_store.get_key(purpose=key_purpose, key_type="private")
 
     payload = JWTHelper.encode(json, jwt_key.kid, key_store, key_purpose)
 
-    jwe_key = key_store.get_key_for_purpose_and_type(key_purpose, "public")
+    jwe_key = key_store.get_key(purpose=key_purpose, key_type="public", service=encryption_service)
 
     return JWEHelper.encrypt(payload, jwe_key.kid, key_store, key_purpose)

--- a/sdc/crypto/key_store.py
+++ b/sdc/crypto/key_store.py
@@ -40,7 +40,10 @@ class KeyStore:
     def __init__(self, keys):
         try:
             self.keys = {
-                kid: Key(kid, key['purpose'], key['type'], key['value'], key.get('service')) for kid, key in keys['keys'].items()
+                kid: Key(
+                    kid, key["purpose"], key["type"], key["value"], key.get("service")
+                )
+                for kid, key in keys["keys"].items()
             }
 
         except KeyError as e:
@@ -63,7 +66,7 @@ class KeyStore:
         else:
             return key
 
-    def get_key_for_purpose(self, purpose, key_type, service=None):
+    def get_key(self, *, purpose, key_type, service=None):
         """
         Gets a list of keys that match the search criteria, and returns the first key in that list
         Note, if there are many keys that match the criteria, the one you get back will be random from that list
@@ -72,10 +75,13 @@ class KeyStore:
 
         keys = self.keys.values()
 
-        if service:
-            key = [key for key in keys if key.purpose == purpose and key.key_type == key_type and key.service == service]
-        else:
-            key = [key for key in keys if key.purpose == purpose and key.key_type == key_type]
+        key = [
+            key
+            for key in keys
+            if key.purpose == purpose
+            and key.key_type == key_type
+            and (not service or key.service == service)
+        ]
         try:
             return key[0]
         except IndexError:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,5 @@
+from sdc.crypto.key_store import KeyStore
+
 TEST_DO_NOT_USE_SR_PRIVATE_PEM = """-----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEAt8LZnIhuOdL/BC029GOaJkVUAqgp2PcmbFr2Qwhf/514DUUQ
 9sKJ1rvwvbmmW2zE8JRtdY3ey0RXGtMn5UZHs8NReHzMxvsmHN4VuaGEnFmPwO82
@@ -149,3 +151,50 @@ livlorbF2L8+LF01V7GhkrwXV+gBitIo7c2bGJjVVKIlJNK8aYqm2vnyli/J8ClS
 vQIDAQAB
 -----END PUBLIC KEY-----
 """
+
+
+# jwt.io public key signed
+TEST_DO_NOT_USE_PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
+MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3Wojg
+GHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlv
+dbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GU
+nKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB
+-----END PUBLIC KEY-----"""
+
+
+def get_mock_key_store(key_purpose):
+    return KeyStore(
+        {
+            "keys": {
+                "e19091072f920cbf3ca9f436ceba309e7d814a62": {
+                    "purpose": key_purpose,
+                    "type": "private",
+                    "value": TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                },
+                "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {
+                    "purpose": key_purpose,
+                    "type": "private",
+                    "value": TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                    "service": "some-service",
+                },
+                "EDCRRM": {
+                    "purpose": key_purpose,
+                    "type": "public",
+                    "value": TEST_DO_NOT_USE_PUBLIC_KEY,
+                    "service": "some-service",
+                },
+                "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {
+                    "purpose": key_purpose,
+                    "type": "public",
+                    "value": TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
+                    "service": "some-service",
+                },
+                "KID_FOR_EQ_V2": {
+                    "purpose": key_purpose,
+                    "type": "public",
+                    "value": TEST_DO_NOT_USE_PUBLIC_KEY,
+                    "service": "eq_v2",
+                },
+            }
+        }
+    )

--- a/tests/test_decrypter.py
+++ b/tests/test_decrypter.py
@@ -24,16 +24,20 @@ class TestDecrypter:
         "keys": {
             "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'private',
-                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM},
+                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                                                         'service': 'blah'},
             "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                       'type': 'private',
-                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM},
+                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                                                      'service': 'blah'},
             "EDCRRM": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                        'type': 'public',
-                       'value': TEST_DO_NOT_USE_PUBLIC_KEY},
+                       'value': TEST_DO_NOT_USE_PUBLIC_KEY,
+                       'service': 'blah'},
             "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'public',
-                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM},
+                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
+                                                         'service': 'blah'},
         }
     })
 

--- a/tests/test_decrypter.py
+++ b/tests/test_decrypter.py
@@ -1,45 +1,16 @@
 import pytest
 
 from sdc.crypto.decrypter import decrypt
-from sdc.crypto.key_store import KeyStore
 from sdc.crypto.exceptions import InvalidTokenException
-from tests import TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM, TEST_DO_NOT_USE_SR_PRIVATE_PEM
 from tests import TOO_FEW_TOKENS_JWE, VALID_JWE
-
+from tests import get_mock_key_store
 
 KEY_PURPOSE_AUTHENTICATION = "authentication"
-
-# jwt.io public key signed
-TEST_DO_NOT_USE_PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3Wojg
-GHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlv
-dbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GU
-nKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB
------END PUBLIC KEY-----"""
 
 
 class TestDecrypter:
 
-    key_store = KeyStore({
-        "keys": {
-            "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                                                         'type': 'private',
-                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
-                                                         'service': 'blah'},
-            "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                                                      'type': 'private',
-                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
-                                                      'service': 'blah'},
-            "EDCRRM": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                       'type': 'public',
-                       'value': TEST_DO_NOT_USE_PUBLIC_KEY,
-                       'service': 'blah'},
-            "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                                                         'type': 'public',
-                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
-                                                         'service': 'blah'},
-        }
-    })
+    key_store = get_mock_key_store(KEY_PURPOSE_AUTHENTICATION)
 
     def test_decrypt(self):
         json = decrypt(VALID_JWE, self.key_store, KEY_PURPOSE_AUTHENTICATION)

--- a/tests/test_encrypter.py
+++ b/tests/test_encrypter.py
@@ -1,0 +1,18 @@
+import json
+
+from sdc.crypto.encrypter import encrypt
+from tests import get_mock_key_store
+
+KEY_PURPOSE_AUTHENTICATION = "authentication"
+
+
+class TestEncrypter:
+
+    key_store = get_mock_key_store(KEY_PURPOSE_AUTHENTICATION)
+
+    def test_encrypt(self):
+        """
+        This is to validate encrypt is able to run without any issues.
+        The tokens is different on each run, hence not asserted.
+        """
+        assert encrypt(json.dumps({"test": "test"}), self.key_store, KEY_PURPOSE_AUTHENTICATION)

--- a/tests/test_jwe_helper.py
+++ b/tests/test_jwe_helper.py
@@ -41,16 +41,20 @@ class TestJWEHelper:
         "keys": {
             "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'private',
-                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM},
+                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                                                         'service': 'blah'},
             "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                       'type': 'private',
-                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM},
+                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                                                      'service': 'blah'},
             "EDCRRM": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                        'type': 'public',
-                       'value': TEST_DO_NOT_USE_PUBLIC_KEY},
+                       'value': TEST_DO_NOT_USE_PUBLIC_KEY,
+                       'service': 'blah'},
             "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'public',
-                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM},
+                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
+                                                         'service': 'blah'},
         }
     })
 

--- a/tests/test_jwe_helper.py
+++ b/tests/test_jwe_helper.py
@@ -42,19 +42,19 @@ class TestJWEHelper:
             "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'private',
                                                          'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
-                                                         'service': 'blah'},
+                                                         'service': 'some-service'},
             "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                       'type': 'private',
                                                       'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
-                                                      'service': 'blah'},
+                                                      'service': 'some-service'},
             "EDCRRM": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                        'type': 'public',
                        'value': TEST_DO_NOT_USE_PUBLIC_KEY,
-                       'service': 'blah'},
+                       'service': 'some-service'},
             "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'public',
                                                          'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
-                                                         'service': 'blah'},
+                                                         'service': 'some-service'},
         }
     })
 

--- a/tests/test_jwt_helper.py
+++ b/tests/test_jwt_helper.py
@@ -44,19 +44,24 @@ class TestTokenHelper:
         "keys": {
             "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'private',
-                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM},
+                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                                                         'service': 'blah'},
             "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                       'type': 'private',
-                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM},
+                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                                                      'service': 'blah'},
             "EDCRRM": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                        'type': 'public',
-                       'value': TEST_DO_NOT_USE_PUBLIC_KEY},
+                       'value': TEST_DO_NOT_USE_PUBLIC_KEY,
+                       'service': 'blah'},
             "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'public',
-                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM},
+                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
+                                                         'service': 'blah'},
             "EQ_USER_AUTHENTICATION_EQ_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                               'type': 'private',
-                                              'value': TEST_DO_NOT_USE_EQ_PRIVATE_KEY},
+                                              'value': TEST_DO_NOT_USE_EQ_PRIVATE_KEY,
+                                              'service': 'blah'},
 
         }
     })
@@ -64,7 +69,8 @@ class TestTokenHelper:
         "keys": {
             "EQ_USER_AUTHENTICATION_EQ_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                               'type': 'public',
-                                              'value': TEST_DO_NOT_USE_EQ_PUBLIC_KEY},
+                                              'value': TEST_DO_NOT_USE_EQ_PUBLIC_KEY,
+                                              'service': 'blah'},
         }
     })
 

--- a/tests/test_jwt_helper.py
+++ b/tests/test_jwt_helper.py
@@ -45,23 +45,23 @@ class TestTokenHelper:
             "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'private',
                                                          'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
-                                                         'service': 'blah'},
+                                                         'service': 'some-service'},
             "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                       'type': 'private',
                                                       'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
-                                                      'service': 'blah'},
+                                                      'service': 'some-service'},
             "EDCRRM": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                        'type': 'public',
                        'value': TEST_DO_NOT_USE_PUBLIC_KEY,
-                       'service': 'blah'},
+                       'service': 'some-service'},
             "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'public',
                                                          'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
-                                                         'service': 'blah'},
+                                                         'service': 'some-service'},
             "EQ_USER_AUTHENTICATION_EQ_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                               'type': 'private',
                                               'value': TEST_DO_NOT_USE_EQ_PRIVATE_KEY,
-                                              'service': 'blah'},
+                                              'service': 'some-service'},
 
         }
     })
@@ -70,7 +70,7 @@ class TestTokenHelper:
             "EQ_USER_AUTHENTICATION_EQ_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                               'type': 'public',
                                               'value': TEST_DO_NOT_USE_EQ_PUBLIC_KEY,
-                                              'service': 'blah'},
+                                              'service': 'some-service'},
         }
     })
 

--- a/tests/test_key_store.py
+++ b/tests/test_key_store.py
@@ -22,16 +22,25 @@ class TestKeyStore:
         "keys": {
             "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'private',
-                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM},
+                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                                                         'service': 'blah'},
             "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                       'type': 'private',
-                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM},
+                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
+                                                      'service': 'blah'},
             "EDCRRM": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                        'type': 'public',
-                       'value': TEST_DO_NOT_USE_PUBLIC_KEY},
+                       'value': TEST_DO_NOT_USE_PUBLIC_KEY,
+                       'service': 'blah'},
+
             "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'public',
-                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM},
+                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
+                                                         'service': 'blah'},
+            "KID_FOR_EQ_V2": {'purpose': KEY_PURPOSE_AUTHENTICATION,
+                              'type': 'public',
+                              'value': TEST_DO_NOT_USE_PUBLIC_KEY,
+                              'service': 'eq_v2'},
         }
     })
 
@@ -54,9 +63,25 @@ class TestKeyStore:
         assert result.key_type == "private"
         assert result.value == TEST_DO_NOT_USE_SR_PRIVATE_PEM
 
+    def test_get_key_for_purpose_type_and_service(self):
+        """
+        Test that we get a key if there is one in the store that matches the criteria
+        Note that if there are many, you'll get a random one.
+        """
+        result = self.key_store.get_key_for_purpose_type_and_service(KEY_PURPOSE_AUTHENTICATION, "public", "eq_v2")
+        assert result.kid == "KID_FOR_EQ_V2"
+        assert result.purpose == KEY_PURPOSE_AUTHENTICATION
+        assert result.key_type == "public"
+        assert result.value == TEST_DO_NOT_USE_PUBLIC_KEY
+
     def test_get_key_for_purpose_and_type_not_found(self):
         """Test that None is returned if no keys in the store have both the specified key_type and purpose"""
         result = self.key_store.get_key_for_purpose_and_type(KEY_PURPOSE_SUBMISSION, "private")
+        assert result is None
+
+    def test_get_key_for_purpose_type_and_service_not_found(self):
+        """Test that None is returned if no keys in the store have both the specified key_type, purpose and service"""
+        result = self.key_store.get_key_for_purpose_type_and_service(KEY_PURPOSE_SUBMISSION, "private", "eq_v3")
         assert result is None
 
     @staticmethod

--- a/tests/test_key_store.py
+++ b/tests/test_key_store.py
@@ -1,48 +1,16 @@
 import pytest
-
-from sdc.crypto.key_store import KeyStore, validate_required_keys
 from sdc.crypto.exceptions import CryptoError, InvalidTokenException
-from tests import TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM, TEST_DO_NOT_USE_SR_PRIVATE_PEM
+from sdc.crypto.key_store import KeyStore, validate_required_keys
+from tests import TEST_DO_NOT_USE_SR_PRIVATE_PEM
+from tests import get_mock_key_store, TEST_DO_NOT_USE_PUBLIC_KEY
 
 KEY_PURPOSE_AUTHENTICATION = "authentication"
 KEY_PURPOSE_SUBMISSION = "submission"
 
-# jwt.io public key signed
-TEST_DO_NOT_USE_PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
-MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDdlatRjRjogo3Wojg
-GHFHYLugdUWAY9iR3fy4arWNA1KoS8kVw33cJibXr8bvwUAUparCwlv
-dbH6dvEOfou0/gCFQsHUfQrSDv+MuSUMAe8jzKE4qW+jK+xQU9a03GU
-nKHkkle+Q0pX/g6jXZ7r1/xAK5Do2kQ+X5xK9cipRgEKwIDAQAB
------END PUBLIC KEY-----"""
-
 
 class TestKeyStore:
 
-    key_store = KeyStore({
-        "keys": {
-            "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                                                         'type': 'private',
-                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM
-                                                         },
-            "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                                                      'type': 'private',
-                                                      'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
-                                                      'service': 'blah'},
-            "EDCRRM": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                       'type': 'public',
-                       'value': TEST_DO_NOT_USE_PUBLIC_KEY,
-                       'service': 'blah'},
-
-            "709eb42cfee5570058ce0711f730bfbb7d4c8ade": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                                                         'type': 'public',
-                                                         'value': TEST_DO_NOT_USE_UPSTREAM_PUBLIC_PEM,
-                                                         'service': 'blah'},
-            "KID_FOR_EQ_V2": {'purpose': KEY_PURPOSE_AUTHENTICATION,
-                              'type': 'public',
-                              'value': TEST_DO_NOT_USE_PUBLIC_KEY,
-                              'service': 'eq_v2'},
-        }
-    })
+    key_store = get_mock_key_store(KEY_PURPOSE_AUTHENTICATION)
 
     def test_get_key_by_kid_with_incorrect_type(self):
         with pytest.raises(InvalidTokenException):
@@ -52,36 +20,37 @@ class TestKeyStore:
         with pytest.raises(InvalidTokenException):
             self.key_store.get_key_by_kid(KEY_PURPOSE_SUBMISSION, "e19091072f920cbf3ca9f436ceba309e7d814a62", "private")
 
-    def test_get_key_for_purpose_and_type_no_service(self):
+    def test_get_key_with_purpose_and_type_no_service(self):
         """
         Test that we get a key if there is one in the store that matches the criteria
         Note that if there are many, you'll get a random one.
         """
-        result = self.key_store.get_key_for_purpose(KEY_PURPOSE_AUTHENTICATION, "private")
+        result = self.key_store.get_key(purpose=KEY_PURPOSE_AUTHENTICATION, key_type="private")
         assert result.kid in ["e19091072f920cbf3ca9f436ceba309e7d814a62", "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY"]
         assert result.purpose == KEY_PURPOSE_AUTHENTICATION
         assert result.key_type == "private"
         assert result.value == TEST_DO_NOT_USE_SR_PRIVATE_PEM
 
-    def test_get_key_for_purpose_type_and_service(self):
+    def test_get_key_with_purpose_type_and_service(self):
         """
         Test that we get a key if there is one in the store that matches the criteria
         Note that if there are many, you'll get a random one.
         """
-        result = self.key_store.get_key_for_purpose(KEY_PURPOSE_AUTHENTICATION, "public", "eq_v2")
+        result = self.key_store.get_key(purpose=KEY_PURPOSE_AUTHENTICATION, key_type="public", service="eq_v2")
         assert result.kid == "KID_FOR_EQ_V2"
         assert result.purpose == KEY_PURPOSE_AUTHENTICATION
         assert result.key_type == "public"
         assert result.value == TEST_DO_NOT_USE_PUBLIC_KEY
 
-    def test_get_key_for_purpose_and_type_not_found(self):
-        """Test that None is returned if no keys in the store have both the specified key_type and purpose"""
-        result = self.key_store.get_key_for_purpose(KEY_PURPOSE_SUBMISSION, "private")
-        assert result is None
-
-    def test_get_key_for_purpose_type_and_service_not_found(self):
-        """Test that None is returned if no keys in the store have both the specified key_type, purpose and service"""
-        result = self.key_store.get_key_for_purpose(KEY_PURPOSE_SUBMISSION, "private", "eq_v3")
+    @pytest.mark.parametrize(
+        "service",
+        ["eq_v3", None],
+    )
+    def test_get_key_not_found(self, service):
+        """Test that None is returned if no keys in the store matches the criteria"""
+        result = self.key_store.get_key(
+            purpose=KEY_PURPOSE_SUBMISSION, key_type="private", service=service
+        )
         assert result is None
 
     @staticmethod

--- a/tests/test_key_store.py
+++ b/tests/test_key_store.py
@@ -22,8 +22,8 @@ class TestKeyStore:
         "keys": {
             "e19091072f920cbf3ca9f436ceba309e7d814a62": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                          'type': 'private',
-                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
-                                                         'service': 'blah'},
+                                                         'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM
+                                                         },
             "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY": {'purpose': KEY_PURPOSE_AUTHENTICATION,
                                                       'type': 'private',
                                                       'value': TEST_DO_NOT_USE_SR_PRIVATE_PEM,
@@ -52,12 +52,12 @@ class TestKeyStore:
         with pytest.raises(InvalidTokenException):
             self.key_store.get_key_by_kid(KEY_PURPOSE_SUBMISSION, "e19091072f920cbf3ca9f436ceba309e7d814a62", "private")
 
-    def test_get_key_for_purpose_and_type(self):
+    def test_get_key_for_purpose_and_type_no_service(self):
         """
         Test that we get a key if there is one in the store that matches the criteria
         Note that if there are many, you'll get a random one.
         """
-        result = self.key_store.get_key_for_purpose_and_type(KEY_PURPOSE_AUTHENTICATION, "private")
+        result = self.key_store.get_key_for_purpose(KEY_PURPOSE_AUTHENTICATION, "private")
         assert result.kid in ["e19091072f920cbf3ca9f436ceba309e7d814a62", "EQ_USER_AUTHENTICATION_SR_PRIVATE_KEY"]
         assert result.purpose == KEY_PURPOSE_AUTHENTICATION
         assert result.key_type == "private"
@@ -68,7 +68,7 @@ class TestKeyStore:
         Test that we get a key if there is one in the store that matches the criteria
         Note that if there are many, you'll get a random one.
         """
-        result = self.key_store.get_key_for_purpose_type_and_service(KEY_PURPOSE_AUTHENTICATION, "public", "eq_v2")
+        result = self.key_store.get_key_for_purpose(KEY_PURPOSE_AUTHENTICATION, "public", "eq_v2")
         assert result.kid == "KID_FOR_EQ_V2"
         assert result.purpose == KEY_PURPOSE_AUTHENTICATION
         assert result.key_type == "public"
@@ -76,12 +76,12 @@ class TestKeyStore:
 
     def test_get_key_for_purpose_and_type_not_found(self):
         """Test that None is returned if no keys in the store have both the specified key_type and purpose"""
-        result = self.key_store.get_key_for_purpose_and_type(KEY_PURPOSE_SUBMISSION, "private")
+        result = self.key_store.get_key_for_purpose(KEY_PURPOSE_SUBMISSION, "private")
         assert result is None
 
     def test_get_key_for_purpose_type_and_service_not_found(self):
         """Test that None is returned if no keys in the store have both the specified key_type, purpose and service"""
-        result = self.key_store.get_key_for_purpose_type_and_service(KEY_PURPOSE_SUBMISSION, "private", "eq_v3")
+        result = self.key_store.get_key_for_purpose(KEY_PURPOSE_SUBMISSION, "private", "eq_v3")
         assert result is None
 
     @staticmethod


### PR DESCRIPTION
## What? and Why?
- Minor change to support selecting a key from the key store based on the service name.
- This is required as RAS now requires choosing between two keys for the same purpose (eQ runner v2/v3)

Worth considering updating test coverage, adding a linter/formatter in the near future. Not added part of this to keep changes relevant and to a minimum.

## How to review
- Ensure the changes are appropriate and that there are no breaking changes.

## Checklist
  - [ ] CHANGELOG.md updated? (if required)
