### PR TITLE
Add Permissions to Workflow & Pin Unpinned Tags for Non-Immutable Actions

### DIFF
--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -11,9 +11,9 @@ jobs:
     name: Build and publish distribution to PyPI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.9
       - name: Install pypa/build

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -32,6 +32,6 @@ jobs:
           .
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -32,6 +32,6 @@ jobs:
           .
       - name: Publish distribution 📦 to PyPI
         if: startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish_to_pypi.yaml
+++ b/.github/workflows/publish_to_pypi.yaml
@@ -6,9 +6,10 @@ on:
 
 jobs:
   build-and-publish:
+    permissions:
+      contents: read
     name: Build and publish distribution to PyPI
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.9

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,7 +24,7 @@ jobs:
         run: pip install pipenv==2023.12.1
       - name: Cache virtualenv
         id: cache-virtualenv
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.local/share/virtualenvs/
           key: ${{ runner.os }}-${{ matrix.python-version }}-virtualenvs-${{ hashFiles('Pipfile.lock') }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - "master"
 
+permissions:
+  contents: read
+
 jobs:
   python-dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,7 +24,7 @@ jobs:
         run: pip install pipenv==2023.12.1
       - name: Cache virtualenv
         id: cache-virtualenv
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.local/share/virtualenvs/
           key: ${{ runner.os }}-${{ matrix.python-version }}-virtualenvs-${{ hashFiles('Pipfile.lock') }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,11 +5,10 @@ on:
     branches:
       - "master"
 
-permissions:
-  contents: read
-
 jobs:
   python-dependencies:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -34,6 +33,8 @@ jobs:
         run: pipenv install --dev
 
   test-unit:
+    permissions:
+      contents: read
     needs: python-dependencies
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
         python-version: ['3.12','3.11','3.10','3.9']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -41,16 +41,16 @@ jobs:
       matrix:
         python-version: ['3.12','3.11','3.10','3.9']
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install pipenv
         run: pip install pipenv==2023.12.1
       - name: Cache virtualenv
         id: cache-virtualenv
-        uses: actions/cache@v2
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ~/.local/share/virtualenvs/
           key: ${{ runner.os }}-${{ matrix.python-version }}-virtualenvs-${{ hashFiles('Pipfile.lock') }}


### PR DESCRIPTION
## What? and Why?
Code Scanning has been enabled in some of our Github Repositories is highlighting issues. 
This PR also resolves the deprecated cache warning from Github Actions and Pins all actions to a commit hash

This PR resolves these issues:

- Workflow does not contain permissions
- Unpinned tag for a non-immutable Action in workflow

## How to review
Check if changes make sense and resolves CodeQL errors

